### PR TITLE
Allow direct cachify instance access to perform explicit cache reset actions

### DIFF
--- a/py_cachify/__init__.py
+++ b/py_cachify/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .backend.cached import cached
 from .backend.exceptions import CachifyInitError, CachifyLockError
-from .backend.lib import init_cachify, get_cachify
+from .backend.lib import get_cachify, init_cachify
 from .backend.lock import once
 
 

--- a/py_cachify/__init__.py
+++ b/py_cachify/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .backend.cached import cached
 from .backend.exceptions import CachifyInitError, CachifyLockError
-from .backend.lib import init_cachify
+from .backend.lib import init_cachify, get_cachify
 from .backend.lock import once
 
 
@@ -10,6 +10,7 @@ __all__ = [
     'CachifyInitError',
     'CachifyLockError',
     'init_cachify',
+    'get_cachify',
     'cached',
     'once',
     'sync',


### PR DESCRIPTION
# Description
Allow direct cachify instance access to perform explicit cache reset actions.


# Checklist:

**I have ...**
- [x] tested the code
- [ ] added & updated automated tests
- [x] performed a self-review of own code
- [x] checked the new code does not generate new warnings

# Additional Notes for Reviewers
It's an overkill to export direct access to cachify, some simpler functions would be enough.
