### PR TITLE
Add TypeIs support

### DIFF
--- a/py_cachify/__init__.py
+++ b/py_cachify/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from .backend.cached import cached
 from .backend.exceptions import CachifyInitError, CachifyLockError
 from .backend.helpers import Decoder, Encoder

--- a/py_cachify/backend/cached.py
+++ b/py_cachify/backend/cached.py
@@ -1,5 +1,5 @@
 import inspect
-from functools import partial, wraps
+from functools import wraps
 from typing import Awaitable, Callable, Tuple, TypeVar, Union, cast, overload
 
 from typing_extensions import ParamSpec, deprecated
@@ -70,14 +70,11 @@ def cached(key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder,
 def sync_cached(
     key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder, Decoder], None] = None
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    return cast(Callable[[Callable[P, R]], Callable[P, R]], partial(cached, key=key, ttl=ttl, enc_dec=enc_dec))
+    return cached(key=key, ttl=ttl, enc_dec=enc_dec)
 
 
 @deprecated('async_cached is deprecated, use cached instead. Scheduled for removal in 1.3.0')
 def async_cached(
     key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder, Decoder], None] = None
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
-    return cast(
-        Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]],
-        partial(cached, key=key, ttl=ttl, enc_dec=enc_dec),
-    )
+    return cached(key=key, ttl=ttl, enc_dec=enc_dec)

--- a/py_cachify/backend/cached.py
+++ b/py_cachify/backend/cached.py
@@ -15,16 +15,16 @@ P = ParamSpec('P')
 
 def cached(key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder, Decoder], None] = None) -> SyncOrAsync:
     @overload
-    def _decorator(
+    def _cached_inner(
         _func: Callable[P, Awaitable[R]],
     ) -> Callable[P, Awaitable[R]]: ...
 
     @overload
-    def _decorator(
+    def _cached_inner(
         _func: Callable[P, R],
     ) -> Callable[P, R]: ...
 
-    def _decorator(  # type: ignore[misc]
+    def _cached_inner(  # type: ignore[misc]
         _func: Union[Callable[P, R], Callable[P, Awaitable[R]]],
     ) -> Union[Callable[P, R], Callable[P, Awaitable[R]]]:
         signature = inspect.signature(_func)
@@ -63,7 +63,7 @@ def cached(key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder,
 
             return _sync_wrapper
 
-    return _decorator
+    return _cached_inner
 
 
 @deprecated('sync_cached is deprecated, use cached instead. Scheduled for removal in 1.3.0')

--- a/py_cachify/backend/cached.py
+++ b/py_cachify/backend/cached.py
@@ -1,82 +1,83 @@
-from __future__ import annotations
-
 import inspect
 from functools import partial, wraps
-from typing import Awaitable, Callable, Optional, Tuple, TypeVar, Union, cast
+from typing import Awaitable, Callable, Tuple, TypeVar, Union, cast, overload
 
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, deprecated
 
 from py_cachify.backend.lib import get_cachify
 
-from .helpers import Decoder, Encoder, encode_decode_value, get_full_key_from_signature, is_coroutine
+from .helpers import Decoder, Encoder, SyncOrAsync, encode_decode_value, get_full_key_from_signature, is_coroutine
 
 
 R = TypeVar('R')
 P = ParamSpec('P')
 
 
-def _decorator(
-    _func: Union[Callable[P, R], Callable[P, Awaitable[R]]],
-    key: str,
-    ttl: Union[int, None] = None,
-    enc_dec: Optional[Tuple[Encoder, Decoder]] = None,
-) -> Union[Callable[P, R], Callable[P, Awaitable[R]]]:
-    signature = inspect.signature(_func)
+def cached(key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder, Decoder], None] = None) -> SyncOrAsync:
+    @overload
+    def _decorator(
+        _func: Callable[P, Awaitable[R]],
+    ) -> Callable[P, Awaitable[R]]: ...
 
-    enc, dec = None, None
-    if enc_dec is not None:
-        enc, dec = enc_dec
+    @overload
+    def _decorator(
+        _func: Callable[P, R],
+    ) -> Callable[P, R]: ...
 
-    if is_coroutine(_func):
-        _awaitable_func = _func
+    def _decorator(  # type: ignore[misc]
+        _func: Union[Callable[P, R], Callable[P, Awaitable[R]]],
+    ) -> Union[Callable[P, R], Callable[P, Awaitable[R]]]:
+        signature = inspect.signature(_func)
 
-        @wraps(_awaitable_func)
-        async def _async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            cachify = get_cachify()
-            _key = get_full_key_from_signature(bound_args=signature.bind(*args, **kwargs), key=key)
-            if val := await cachify.a_get(key=_key):
-                return encode_decode_value(encoder_decoder=dec, val=val)
+        enc, dec = None, None
+        if enc_dec is not None:
+            enc, dec = enc_dec
 
-            res = await _awaitable_func(*args, **kwargs)
-            await cachify.a_set(key=_key, val=encode_decode_value(encoder_decoder=enc, val=res), ttl=ttl)
-            return res
+        if is_coroutine(_func):
+            _awaitable_func = _func
 
-        return cast(Callable[P, Awaitable[R]], _async_wrapper)
-    else:
+            @wraps(_awaitable_func)
+            async def _async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                cachify = get_cachify()
+                _key = get_full_key_from_signature(bound_args=signature.bind(*args, **kwargs), key=key)
+                if val := await cachify.a_get(key=_key):
+                    return encode_decode_value(encoder_decoder=dec, val=val)
 
-        @wraps(_func)
-        def _sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            cachify = get_cachify()
-            _key = get_full_key_from_signature(bound_args=signature.bind(*args, **kwargs), key=key)
-            if val := cachify.get(key=_key):
-                return encode_decode_value(encoder_decoder=dec, val=val)
+                res = await _awaitable_func(*args, **kwargs)
+                await cachify.a_set(key=_key, val=encode_decode_value(encoder_decoder=enc, val=res), ttl=ttl)
+                return res
 
-            res = _func(*args, **kwargs)
-            cachify.set(key=_key, val=encode_decode_value(encoder_decoder=enc, val=res), ttl=ttl)
-            return cast(R, res)
+            return _async_wrapper
+        else:
 
-        return cast(Callable[P, R], _sync_wrapper)
+            @wraps(_func)  # type: ignore[unreachable]
+            def _sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                cachify = get_cachify()
+                _key = get_full_key_from_signature(bound_args=signature.bind(*args, **kwargs), key=key)
+                if val := cachify.get(key=_key):
+                    return encode_decode_value(encoder_decoder=dec, val=val)
+
+                res = _func(*args, **kwargs)
+                cachify.set(key=_key, val=encode_decode_value(encoder_decoder=enc, val=res), ttl=ttl)
+                return cast(R, res)
+
+            return _sync_wrapper
+
+    return _decorator
 
 
-def cached(
-    key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder, Decoder], None] = None
-) -> Callable[[Union[Callable[P, Awaitable[R]], Callable[P, R]]], Union[Callable[P, Awaitable[R]], Callable[P, R]]]:
-    return cast(
-        Callable[[Union[Callable[P, Awaitable[R]], Callable[P, R]]], Union[Callable[P, Awaitable[R]], Callable[P, R]]],
-        partial(_decorator, key=key, ttl=ttl, enc_dec=enc_dec),
-    )
-
-
+@deprecated('sync_cached is deprecated, use cached instead. Scheduled for removal in 1.3.0')
 def sync_cached(
     key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder, Decoder], None] = None
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    return cast(Callable[[Callable[P, R]], Callable[P, R]], partial(_decorator, key=key, ttl=ttl, enc_dec=enc_dec))
+    return cast(Callable[[Callable[P, R]], Callable[P, R]], partial(cached, key=key, ttl=ttl, enc_dec=enc_dec))
 
 
+@deprecated('async_cached is deprecated, use cached instead. Scheduled for removal in 1.3.0')
 def async_cached(
     key: str, ttl: Union[int, None] = None, enc_dec: Union[Tuple[Encoder, Decoder], None] = None
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
     return cast(
         Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]],
-        partial(_decorator, key=key, ttl=ttl, enc_dec=enc_dec),
+        partial(cached, key=key, ttl=ttl, enc_dec=enc_dec),
     )

--- a/py_cachify/backend/helpers.py
+++ b/py_cachify/backend/helpers.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from typing import Any, Awaitable, Callable, TypeVar, Union, overload
 
@@ -25,7 +26,7 @@ def get_full_key_from_signature(bound_args: inspect.BoundArguments, key: str) ->
 def is_coroutine(
     func: Callable[P, Union[R, Awaitable[R]]],
 ) -> TypeIs[Callable[P, Awaitable[R]]]:
-    return inspect.iscoroutinefunction(func)
+    return asyncio.iscoroutinefunction(func)
 
 
 def encode_decode_value(encoder_decoder: Union[Encoder, Decoder, None], val: Any) -> Any:

--- a/py_cachify/backend/lock.py
+++ b/py_cachify/backend/lock.py
@@ -1,8 +1,8 @@
 import inspect
 import logging
 from contextlib import asynccontextmanager, contextmanager
-from functools import partial, wraps
-from typing import Any, AsyncGenerator, Awaitable, Callable, Generator, TypeVar, Union, cast
+from functools import wraps
+from typing import Any, AsyncGenerator, Awaitable, Callable, Generator, TypeVar, Union
 
 from typing_extensions import ParamSpec, deprecated, overload
 
@@ -110,17 +110,11 @@ def once(key: str, raise_on_locked: bool = False, return_on_locked: Any = None) 
 def sync_once(
     key: str, raise_on_locked: bool = False, return_on_locked: Any = None
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    return cast(
-        Callable[[Callable[P, R]], Callable[P, R]],
-        partial(once, key=key, raise_on_locked=raise_on_locked, return_on_locked=return_on_locked),
-    )
+    return once(key=key, raise_on_locked=raise_on_locked, return_on_locked=return_on_locked)
 
 
 @deprecated('async_once is deprecated, use once instead. Scheduled for removal in 1.3.0')
 def async_once(
     key: str, raise_on_locked: bool = False, return_on_locked: Any = None
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
-    return cast(
-        Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]],
-        partial(once, key=key, raise_on_locked=raise_on_locked, return_on_locked=return_on_locked),
-    )
+    return once(key=key, raise_on_locked=raise_on_locked, return_on_locked=return_on_locked)

--- a/py_cachify/backend/lock.py
+++ b/py_cachify/backend/lock.py
@@ -52,16 +52,16 @@ def lock(key: str) -> Generator[None, None, None]:
 
 def once(key: str, raise_on_locked: bool = False, return_on_locked: Any = None) -> SyncOrAsync:
     @overload
-    def _decorator(
+    def _once_inner(
         _func: Callable[P, Awaitable[R]],
     ) -> Callable[P, Awaitable[R]]: ...
 
     @overload
-    def _decorator(
+    def _once_inner(
         _func: Callable[P, R],
     ) -> Callable[P, R]: ...
 
-    def _decorator(  # type: ignore[misc]
+    def _once_inner(  # type: ignore[misc]
         _func: Union[Callable[P, R], Callable[P, Awaitable[R]]],
     ) -> Union[Callable[P, R], Callable[P, Awaitable[R]]]:
         signature = inspect.signature(_func)
@@ -103,7 +103,7 @@ def once(key: str, raise_on_locked: bool = False, return_on_locked: Any = None) 
 
             return _sync_wrapper
 
-    return _decorator
+    return _once_inner
 
 
 @deprecated('sync_once is deprecated, use once instead. Scheduled for removal in 1.3.0')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,8 @@ omit = [
 
 exclude_lines = [
     'pragma: no cover',
+    '@overload',
+    'SyncOrAsync',
     '@abstract',
     'def __repr__',
     'raise AssertionError',


### PR DESCRIPTION
# Description
- Added TypeIs support
- cached and once can now be used in both cases.
- sync_cached, async_cached, sync_once, async_once have been deprecated and scheduled for removal in 1.3.0


# Checklist:

**I have ...**
- [x] tested the code
- [x] added & updated automated tests
- [x] performed a self-review of own code
- [x] checked the new code does not generate new warnings
