### PR TITLE
Fix default arguments are not respected when crafting cache key

### DIFF
--- a/py_cachify/_backend/_helpers.py
+++ b/py_cachify/_backend/_helpers.py
@@ -14,15 +14,16 @@ _S = TypeVar('_S')
 
 
 def get_full_key_from_signature(bound_args: inspect.BoundArguments, key: str) -> str:
+    bound_args.apply_defaults()
     args_dict = bound_args.arguments
-    args: Tuple[str, Any] = args_dict.pop('args', ())
+    args: Tuple[Any, ...] = args_dict.pop('args', ())
     kwargs: Dict[str, Any] = args_dict.pop('kwargs', {})
     kwargs.update(args_dict)
 
     try:
         return key.format(*args, **kwargs)
-    except IndexError:
-        raise ValueError('Arguments in a key do not match function signature') from None
+    except (IndexError, KeyError):
+        raise ValueError(f'Arguments in a key({key}) do not match function signature params({bound_args})') from None
 
 
 def is_coroutine(

--- a/py_cachify/_backend/_helpers.py
+++ b/py_cachify/_backend/_helpers.py
@@ -15,6 +15,8 @@ _S = TypeVar('_S')
 
 def get_full_key_from_signature(bound_args: inspect.BoundArguments, key: str) -> str:
     bound_args.apply_defaults()
+    _args_repr = f'{bound_args}'
+
     args_dict = bound_args.arguments
     args: Tuple[Any, ...] = args_dict.pop('args', ())
     kwargs: Dict[str, Any] = args_dict.pop('kwargs', {})
@@ -23,7 +25,7 @@ def get_full_key_from_signature(bound_args: inspect.BoundArguments, key: str) ->
     try:
         return key.format(*args, **kwargs)
     except (IndexError, KeyError):
-        raise ValueError(f'Arguments in a key({key}) do not match function signature params({bound_args})') from None
+        raise ValueError(f'Arguments in a key({key}) do not match function signature params({_args_repr})') from None
 
 
 def is_coroutine(


### PR DESCRIPTION
# Description
- Fix default arguments are not being respected when crafting cache key
- Better error message on format key errors (mismatch of key parameters/provided arguments)

# Checklist:
_If any of these are not checked please leave a succinct reason below_

**I have ...**
- [x] tested the code
- [x] added & updated automated tests
- [x] performed a self-review of own code
- [x] checked the new code does not generate new warnings

