### PR TITLE
Change default log level to debug

### DIFF
--- a/py_cachify/_backend/_lock.py
+++ b/py_cachify/_backend/_lock.py
@@ -5,7 +5,7 @@ from asyncio import sleep as asleep
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, TypeVar, Union, cast
 
-from typing_extensions import ParamSpec, Self, deprecated, overload, override
+from typing_extensions import ParamSpec, Self, deprecated, final, overload, override
 
 from ._exceptions import CachifyLockError
 from ._helpers import a_reset, get_full_key_from_signature, is_alocked, is_coroutine, is_locked, reset
@@ -93,6 +93,7 @@ class SyncLockMethods(LockProtocolBase):
         self.release()
 
 
+@final
 class lock(AsyncLockMethods, SyncLockMethods):
     """
     Class to manage locking mechanism for synchronous and asynchronous functions.
@@ -210,7 +211,7 @@ class lock(AsyncLockMethods, SyncLockMethods):
         msg = f'{key} is already locked!'
 
         if do_log:
-            logger.warning(msg)
+            logger.debug(msg)
 
         if do_raise:
             raise CachifyLockError(msg)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -46,8 +46,7 @@ def test_get_full_key_mixed_placeholders(args_kwargs_signature):
     with pytest.raises(
         ValueError,
         match=re.escape(
-            'Arguments in a key(key_{}_{}_{}_{invalid_arg}) '
-            + f'do not match function signature params({bound_args})'
+            'Arguments in a key(key_{}_{}_{}_{invalid_arg}) ' + f'do not match function signature params({bound_args})'
         ),
     ):
         _ = get_full_key_from_signature(bound_args, 'key_{}_{}_{}_{invalid_arg}')

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -132,7 +132,7 @@ def test_lock_get_ttl(init_cachify_fixture, default_expiration, exp, expected):
     ],
 )
 def test_lock_raise_if_cached(mocker, is_already_locked, key, do_raise, expectation):
-    patch_log = mocker.patch('py_cachify._backend._lock.logger.warning')
+    patch_log = mocker.patch('py_cachify._backend._lock.logger.debug')
 
     with expectation:
         lock._raise_if_cached(


### PR DESCRIPTION
# Description
Default log level is now `debug` to prevent unnecessary log pollution

# Checklist:

**I have ...**
- [x] tested the code
- [x] added & updated automated tests
- [x] performed a self-review of own code
- [x] checked the new code does not generate new warnings

